### PR TITLE
Fix: Resolve H2 database URL issue in test configuration

### DIFF
--- a/src/test/java/com/secureauth/oauth2_social_login/Oauth2SocialLoginApplicationTests.java
+++ b/src/test/java/com/secureauth/oauth2_social_login/Oauth2SocialLoginApplicationTests.java
@@ -2,8 +2,10 @@ package com.secureauth.oauth2_social_login;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest
+@SpringBootTest(classes = Oauth2SocialLoginApplication.class)
+@ActiveProfiles("test")
 class Oauth2SocialLoginApplicationTests {
 
 	@Test

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,5 @@
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=password
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
- Added `application-test.properties` in `src/test/resources` with correct H2 database configuration.
- Updated `Oauth2SocialLoginApplicationTests` to use the `test` profile.