### PR TITLE
Fix: Ensure OTP is always a 6-digit number

### DIFF
--- a/src/main/java/com/secureauth/oauth2_social_login/service/otp/OneTimePasswordHelpService.java
+++ b/src/main/java/com/secureauth/oauth2_social_login/service/otp/OneTimePasswordHelpService.java
@@ -7,17 +7,10 @@ import java.util.function.Supplier;
 
 @Service
 public class OneTimePasswordHelpService {
-    private final static Integer LENGTH = 6;
-
     public Supplier<Integer> createRandomOneTimePassword() {
         return () -> {
             Random random = new Random();
-            StringBuilder oneTimePassword = new StringBuilder();
-            for (int i = 0; i < LENGTH; i++) {
-                int randomNumber = random.nextInt(10);
-                oneTimePassword.append(randomNumber);
-            }
-            return Integer.parseInt(oneTimePassword.toString().trim());
+            return 100000 + random.nextInt(900000);
         };
     }
 }


### PR DESCRIPTION
- Updated `createRandomOneTimePassword` method in `OneTimePasswordHelpService` to generate a 6-digit OTP.